### PR TITLE
fix blurry favicons on hidpi displays

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -51,7 +51,7 @@ import tokenize
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon, QWindow
 from PyQt5.QtCore import (pyqtSlot, qInstallMessageHandler, QTimer, QUrl,
-                          QObject, QEvent, pyqtSignal)
+                          QObject, QEvent, pyqtSignal, Qt)
 try:
     import hunter
 except ImportError:
@@ -821,6 +821,7 @@ class Application(QApplication):
 
         self.launch_time = datetime.datetime.now()
         self.focusObjectChanged.connect(self.on_focus_object_changed)
+        self.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
     @pyqtSlot(QObject)
     def on_focus_object_changed(self, obj):


### PR DESCRIPTION
This fixes blurry favicons on hidpi displays.

Related to https://github.com/qutebrowser/qutebrowser/issues/1585

Results on non hidpi display:
![2017-10-15-192153_2560x1080_scrot](https://user-images.githubusercontent.com/2271115/31587248-b723b884-b1de-11e7-991c-73dd748f2c5b.png)

Results on hidpi display:
![2017-10-15-192249_3200x1800_scrot](https://user-images.githubusercontent.com/2271115/31587251-c62826e4-b1de-11e7-8c0a-b3896deb1b0e.png)


